### PR TITLE
Add test for tokenizer

### DIFF
--- a/packages/remark-parse/package.json
+++ b/packages/remark-parse/package.json
@@ -12,6 +12,13 @@
     "parse"
   ],
   "types": "types/index.d.ts",
+  "typesVersions": {
+    ">=3.1": {
+      "*": [
+        "types/ts3.1/*"
+      ]
+    }
+  },
   "homepage": "https://remark.js.org",
   "repository": "https://github.com/remarkjs/remark/tree/master/packages/remark-parse",
   "bugs": "https://github.com/remarkjs/remark/issues",

--- a/packages/remark-parse/types/ts3.1/index.d.ts
+++ b/packages/remark-parse/types/ts3.1/index.d.ts
@@ -1,0 +1,50 @@
+import {Node, Parent, Position} from 'unist'
+import {Parser, Attacher} from 'unified'
+
+declare class RemarkParser extends Parser {
+  blockMethods: string[]
+  inlineTokenizers: {
+    [key: string]: remarkParse.Tokenizer
+  }
+  inlineMethods: string[]
+}
+
+declare namespace remarkParse {
+  interface Parse extends Attacher {
+    (options: RemarkParseOptions): void
+    Parser: typeof RemarkParser
+  }
+
+  type Parser = RemarkParser
+
+  interface RemarkParseOptions {
+    gfm: boolean
+    commonmark: boolean
+    footnotes: boolean
+    blocks: string[]
+    pedantic: boolean
+  }
+
+  interface Add {
+    (node: Node, parent?: Parent): Node
+    test(): Position
+    reset(node: Node, parent?: Node): Node
+  }
+
+  type Eat = (value: string) => Add
+
+  type Locator = (value: string, fromIndex: number) => number
+
+  interface Tokenizer {
+    (eat: Eat, value: string, silent: true): boolean | void
+    (eat: Eat, value: string): Node | void
+    locator?: Locator
+    onlyAtStart?: boolean
+    notInBlock?: boolean
+    notInList?: boolean
+    notInLink?: boolean
+  }
+}
+declare const remarkParse: remarkParse.Parse
+
+export = remarkParse

--- a/packages/remark-parse/types/ts3.1/test.ts
+++ b/packages/remark-parse/types/ts3.1/test.ts
@@ -1,0 +1,61 @@
+import unified = require('unified')
+import * as Unist from 'unist'
+import remarkParse = require('remark-parse')
+
+const parseOptions: Partial<remarkParse.RemarkParseOptions> = {
+  gfm: true,
+  pedantic: true
+}
+
+unified().use(remarkParse, parseOptions)
+
+const badParseOptions: Partial<remarkParse.RemarkParseOptions> = {
+  // $ExpectError
+  gfm: 'true'
+}
+
+const locateMention: remarkParse.Locator = (value, fromIndex) => {
+  return value.indexOf('@', fromIndex)
+}
+
+tokenizeMention.notInLink = true
+tokenizeMention.locator = locateMention
+
+function tokenizeMention(
+  eat: remarkParse.Eat,
+  value: string,
+  silent: true
+): boolean | void
+function tokenizeMention(eat: remarkParse.Eat, value: string): Unist.Node | void
+function tokenizeMention(
+  eat: remarkParse.Eat,
+  value: string,
+  silent?: boolean
+): Unist.Node | boolean | void {
+  const match = /^@(\w+)/.exec(value)
+
+  if (match) {
+    if (silent) {
+      return true
+    }
+
+    const add = eat(match[0])
+    return add({
+      type: 'link',
+      url: 'https://social-network/' + match[1],
+      children: [{type: 'text', value: match[0]}]
+    })
+  }
+}
+
+function mentions(this: unified.Processor) {
+  const Parser = this.Parser as typeof remarkParse.Parser
+  const tokenizers = Parser.prototype.inlineTokenizers
+  const methods = Parser.prototype.inlineMethods
+
+  tokenizers.mention = tokenizeMention
+
+  methods.splice(methods.indexOf('text'), 0, 'mention')
+}
+
+const plugin: unified.Attacher = mentions

--- a/packages/remark-parse/types/ts3.1/tsconfig.json
+++ b/packages/remark-parse/types/ts3.1/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015"],
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": ".",
+    "paths": {
+      "remark-parse": ["index.d.ts"]
+    }
+  }
+}

--- a/packages/remark-parse/types/ts3.1/tslint.json
+++ b/packages/remark-parse/types/ts3.1/tslint.json
@@ -1,0 +1,14 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "callable-types": false,
+    "max-line-length": false,
+    "no-redundant-jsdoc": false,
+    "no-void-expression": false,
+    "only-arrow-functions": false,
+    "semicolon": false,
+    "unified-signatures": false,
+    "whitespace": false,
+    "interface-over-type-literal": false
+  }
+}


### PR DESCRIPTION
It seems functions with props are available from v3.1 of typescript. We need it badly to make our own tokenizer. And, actually, that's one of the reasons why I tried ts-remark project.

But typescript team has changed the way to configure minimum typescript version. So, to test in v3.1+ version, we have to put test files in `types/ts3.1` and configure `package.json` too. 

I make this pr separately because it looks too redundant for me.